### PR TITLE
Generate the controllers virtual module as an ES module

### DIFF
--- a/src/webpack/create-controllers-module.js
+++ b/src/webpack/create-controllers-module.js
@@ -10,7 +10,7 @@
 'use strict';
 
 module.exports = function createControllersVirtualModule(config) {
-    let file = 'module.exports = {';
+    let file = 'export default {';
 
     if ('undefined' === typeof config['controllers']) {
         throw new Error('Your Stimulus configuration file (assets/controllers.json) lacks a "controllers" key.');

--- a/test/webpack/create-controllers-module.test.js
+++ b/test/webpack/create-controllers-module.test.js
@@ -15,14 +15,14 @@ describe('createControllersVirtualModule', () => {
     describe('empty.json', () => {
         it('must return an empty file', () => {
             const config = require('../fixtures/empty.json');
-            expect(createControllersVirtualModule(config)).toEqual('module.exports = {\n};');
+            expect(createControllersVirtualModule(config)).toEqual('export default {\n};');
         });
     });
 
     describe('disabled-controller.json', () => {
         it('must return an empty file', () => {
             const config = require('../fixtures/disabled-controller.json');
-            expect(createControllersVirtualModule(config)).toEqual('module.exports = {\n};');
+            expect(createControllersVirtualModule(config)).toEqual('export default {\n};');
         });
     });
 
@@ -30,7 +30,7 @@ describe('createControllersVirtualModule', () => {
         it('must return an empty file', () => {
             const config = require('../fixtures/disabled-autoimport.json');
             expect(createControllersVirtualModule(config)).toEqual(
-                "module.exports = {\n  '@symfony/mock-module/mock': import(/* webpackMode: \"lazy\" */ '@symfony/mock-module/dist/controller.js'),\n};"
+                "export default {\n  '@symfony/mock-module/mock': import(/* webpackMode: \"lazy\" */ '@symfony/mock-module/dist/controller.js'),\n};"
             );
         });
     });
@@ -39,7 +39,7 @@ describe('createControllersVirtualModule', () => {
         it('must return an empty file', () => {
             const config = require('../fixtures/eager-no-autoimport.json');
             expect(createControllersVirtualModule(config)).toEqual(
-                "module.exports = {\n  '@symfony/mock-module/mock': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/controller.js'),\n};"
+                "export default {\n  '@symfony/mock-module/mock': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/controller.js'),\n};"
             );
         });
     });
@@ -48,7 +48,7 @@ describe('createControllersVirtualModule', () => {
         it('must return a file with the enabled controller', () => {
             const config = require('../fixtures/lazy-autoimport.json');
             expect(createControllersVirtualModule(config)).toEqual(
-                "module.exports = {\n  '@symfony/mock-module/mock': import(/* webpackMode: \"lazy\" */ '@symfony/mock-module/dist/controller.js'),\n};"
+                "export default {\n  '@symfony/mock-module/mock': import(/* webpackMode: \"lazy\" */ '@symfony/mock-module/dist/controller.js'),\n};"
             );
         });
     });


### PR DESCRIPTION
webpack restrict some optimizations to ES modules, bailing out for CommonJS. So using an ES module is better.