### PR TITLE
Add explicit dependency on @babel/plugin-proposal-class-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "stimulus": "^2.0"
     },
     "dependencies": {
+        "@babel/plugin-proposal-class-properties": "^7.12.1",
         "webpack-virtual-modules": "^0.3.2"
     },
     "devDependencies": {


### PR DESCRIPTION
@weaverryan I'm not sure in which context I ended up without this module but I did in a project:

```
yarn dev
yarn run v1.22.5
warning ../../../package.json: No license field
$ encore dev
Running webpack ...

 ERROR  Failed to compile with 1 errors                                                                                                                                                                                    10:41:04 PM

 error  in ./assets/app.js

Syntax Error: Error: Cannot find module '@babel/plugin-proposal-class-properties' from '/home/tgalopin/Projects/citipo/marketing'
    at Array.map (<anonymous>)
    at cachedFunction.next (<anonymous>)
    at Generator.next (<anonymous>)
    at buildRootChain.next (<anonymous>)
    at loadPrivatePartialConfig.next (<anonymous>)
    at Generator.next (<anonymous>)
    at Generator.next (<anonymous>)
    at new Promise (<anonymous>)


Entrypoint app = runtime.js app.js
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Just to avoid that happening again, I propose to put the dependency as explicit. WDYT?