### PR TITLE
Normalize Stimulus controllers names coming from packages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export function startStimulusApp(context) {
         }
 
         symfonyControllers[controllerName].then((module) => {
+            controllerName = controllerName.replace('/', '--');
             application.register(controllerName, module.default);
         });
     }


### PR DESCRIPTION
This would allow to use the new Stimulus 2 syntax for targets and perhaps profits from the data API better as well.

This would replace the controller named `@symfony/ux-dropzone/dropzone` in `@symfony--ux-dropzone--dropzone`, double dashes being the official notation for "directories" in Stimulus.