### PR TITLE
Put @babel/plugin-proposal-class-properties as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
         "test": "webpack --config test/webpack.config.js && jest"
     },
     "peerDependencies": {
+        "@babel/plugin-proposal-class-properties": "^7.0",
         "stimulus": "^2.0"
     },
     "dependencies": {
-        "@babel/plugin-proposal-class-properties": "^7.12.1",
         "webpack-virtual-modules": "^0.3.2"
     },
     "devDependencies": {


### PR DESCRIPTION
I think this is the best option: we show the requirement on the package without actually depending on it directly. WDYT @chapterjason ?