### PR TITLE
Normalize Stimulus controller names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ export function startStimulusApp(context) {
         }
 
         symfonyControllers[controllerName].then((module) => {
+            // Normalize the controller name: remove the initial @ and use Stimulus format
+            controllerName = controllerName.substr(1).replace(/_/g, "-").replace(/\//g, "--");
+
             application.register(controllerName, module.default);
         });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,6 +19,6 @@ describe('startStimulusApp', () => {
         await new Promise(setImmediate);
 
         expect(app.router.modules.length).toBe(1);
-        expect(app.router.modules[0].definition.identifier).toBe('@symfony/mock-module/mock-controller');
+        expect(app.router.modules[0].definition.identifier).toBe('symfony--mock-module--mock-controller');
     });
 });


### PR DESCRIPTION
Following https://github.com/symfony/stimulus-bridge/pull/9, let's stick to something cleaner as after testing several options this is the most reliable one.

This PR introduces breaking changes for users of the bridge if they invoke manually Stimulus controller from vendors. However, I think this is necessary and the bridge isn't used too much in this situation yet. Also, this package is experimental precisely for these situations :) .

If merged, controllers coming from vendors would be normalized the same way the app controllers are: `@symfony/ux-dropzone/dropzone` would become `symfony--ux-dropzone--dropzone`. This is consistent with Stimulus way of doing this and it will allow us to better leverage the Target and Data API.