### PR TITLE
removing class-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,10 @@
     "peerDependencies": {
         "stimulus": "^2.0"
     },
-    "dependencies": {
-        "@babel/plugin-proposal-class-properties": "^7.12.1"
-    },
+    "dependencies": {},
     "devDependencies": {
         "@babel/cli": "^7.12.1",
         "@babel/core": "^7.12.3",
-        "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/preset-env": "^7.12.7",
         "@symfony/mock-module": "file:test/fixtures/module",
         "@symfony/stimulus-testing": "^1.0.0",


### PR DESCRIPTION
See #11.

tl;dr we do not *actually* depend on this library, though Stimulus requires it if you're using its normal `targets =  syntax. However, *how* that currently works with Encore is a bit of a mystery.

Still, I do not believe having this as a dependency solves or does anything.  And since it's not part of any release yet, let's remove it.