### PR TITLE
Fix param type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,6 @@ import { Application } from "stimulus";
 
 declare module "@symfony/stimulus-bridge" {
 
-    export function startStimulusApp(context: __WebpackModuleApi.RequireContext): Application;
+    export function startStimulusApp(context?: __WebpackModuleApi.RequireContext): Application;
 
 }


### PR DESCRIPTION
Just noticed afterwards that in the meantime the type changed to be optional in #10. 

https://github.com/symfony/stimulus-bridge/blob/c29caa8a9ff4217c69c06efbb9036276507a28e0/src/index.js#L22-L24