### PR TITLE
Add workflow to verify dist build

### DIFF
--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -1,0 +1,18 @@
+name: Symfony UX - Verify build
+
+on: [push, pull_request]
+
+jobs:
+    verify:
+        name: Check For Uncomitted Changes
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Build
+              run: |
+                  yarn install
+                  yarn run build
+            - name: Check Git Status
+              run: |
+                  status="$(git status --short)"
+                  [ -z "$status" ]


### PR DESCRIPTION
This workflow builds the plugin and check if there are any git changes, if so the the build will fail.
This ensures that the dist output will always be the latest.