### PR TITLE
Adding a hint of we can't find the package.json file

### DIFF
--- a/dist/webpack/create-controllers-module.js
+++ b/dist/webpack/create-controllers-module.js
@@ -25,7 +25,13 @@ module.exports = function createControllersModule(config) {
   }
 
   for (var packageName in config.controllers) {
-    var packageConfig = require(packageName + '/package.json');
+    var packageConfig = void 0;
+
+    try {
+      packageConfig = require(packageName + '/package.json');
+    } catch (e) {
+      throw new Error("The file \"".concat(packageName, "/package.json\" could not be found. Try running \"yarn install --force\"."));
+    }
 
     for (var controllerName in config.controllers[packageName]) {
       var controllerReference = packageName + '/' + controllerName; // Normalize the controller name: remove the initial @ and use Stimulus format

--- a/src/webpack/create-controllers-module.js
+++ b/src/webpack/create-controllers-module.js
@@ -28,7 +28,14 @@ module.exports = function createControllersModule(config) {
     }
 
     for (let packageName in config.controllers) {
-        const packageConfig = require(packageName + '/package.json');
+        let packageConfig;
+        try {
+            packageConfig = require(packageName + '/package.json');
+        } catch (e) {
+            throw new Error(
+                `The file "${packageName}/package.json" could not be found. Try running "yarn install --force".`
+            );
+        }
 
         for (let controllerName in config.controllers[packageName]) {
             const controllerReference = packageName + '/' + controllerName;


### PR DESCRIPTION
I hit this locally - I (duh) forgot to run `yarn install --force` after installing a UX package. I've tested this on a real project.