### PR TITLE
Fix types import

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,9 +7,9 @@
  * file that was distributed with this source code.
  */
 
-import { Application } from "stimulus";
-
 declare module "@symfony/stimulus-bridge" {
+
+    import { Application } from "stimulus";
 
     export function startStimulusApp(context?: __WebpackModuleApi.RequireContext): Application;
 


### PR DESCRIPTION
As I thought on the first PR https://github.com/symfony/stimulus-bridge/pull/8#discussion_r562621068 imports should be declared inside the module declaration otherwise it can cause errors like: 

```
TS2665: Invalid module name in augmentation. Module '@symfony/stimulus-bridge' resolves to an untyped module at '[...]/node_modules/@symfony/stimulus-bridge/dist/index.js', which cannot be augmented.
```

source: https://stackoverflow.com/a/48846446