### PR TITLE
Fix documentation on how to run encore

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Symfony Flex recipe that will set up everything for you. Finish by
 running Encore:
 
 ```sh
-yarn encore watch
+yarn encore dev --watch
 ```
 
 If you already had Encore installed (and so the recipe did not run), you


### PR DESCRIPTION
Apparently encore needs different parameters than shown in the docs to run. The proposed change seems to work just fine.

Running `yarn encore watch` results in an error:
```bash
✗ yarn encore watch
yarn run v1.22.10
$ /Users/martinhauke/workspace/example/symfony/basic/app/node_modules/.bin/encore watch
Invalid command "watch"

usage encore [dev|prod|production|dev-server]

encore is a thin executable around the webpack or webpack-dev-server executables

Commands:
    dev        : runs webpack for development
       - Supports any webpack options (e.g. --watch)

    dev-server : runs webpack-dev-server
       - --host The hostname/ip address the webpack-dev-server will bind to
       - --port The port the webpack-dev-server will bind to
       - --keep-public-path Do not change the public path (it is usually prefixed by the dev server URL)
       - Supports any webpack-dev-server options

    production : runs webpack for production
       - Supports any webpack options (e.g. --watch)

    encore dev --watch
    encore dev-server
    encore production

error Command failed with exit code 1.
```

Running `yarn encore dev --watch` seems to work.