### PR TITLE
Supporting Stimulus 3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,8 @@ jobs:
             - uses: actions/checkout@master
             - name: Prettier
               run: |
-                  yarn global add prettier@^2.2.0
-                  ~/.yarn/bin/prettier --check {src,test}/**/*.js --config .prettierrc.json
+                  yarn
+                  yarn run prettier --check {src,test}/**/*.js --config .prettierrc.json
 
     tests:
         runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## 3.0.0
+
+Dropped support for `stimulus` 2.0, in favor of `@hotwired/stimulus` version 3.
+You can read about Stimulus version on its [release announcement](https://world.hey.com/hotwired/stimulus-3-c438d432).
+
+The most important change needed is to:
+
+* Remove `stimulus` from your `package.json` file, replace it with `"@hotwired/stimulus": "^3.0"`
+  and run `yarn install`.
+
+* Update all of your controllers to replace any imports for `stimulus` with
+  imports from `@hotwired/stimulus`:
+
+```diff
+-import { Controller } from 'stimulus';
++import { Controller } from '@hotwired/stimulus';
+```
+
+* Upgrade any `symfony/ux-*` PHP packages that you have installed to version 2 or later.
+
 ## 2.0.0
 
 Following the release of Webpack Encore 1.0, this release adapts the stimulus-bridge to Webpack 5

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The Webpack Encore recipe usually handles setting up everything you need.
 But you can also do it manually. First, install the bridge:
 
 ```sh
-yarn add @symfony/stimulus-bridge stimulus --dev
+yarn add @symfony/stimulus-bridge @hotwired/stimulus --dev
 ```
 
 Next, create an `assets/controllers.json` file: Flex will update
@@ -99,7 +99,7 @@ Let's see an example: create a new `assets/controllers/hello_controller.js`
 file (you may already have this):
 
 ```
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
     connect() {
@@ -222,7 +222,7 @@ Next, you can make any controllers lazy by adding a `/* stimulusFetch: 'lazy' */
 comment above that controller:
 
 ```js
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13,9 +13,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.startStimulusApp = startStimulusApp;
 
-var _stimulus = require("stimulus");
+var _stimulus = require("@hotwired/stimulus");
 
-var _webpackHelpers = require("stimulus/webpack-helpers");
+var _stimulusWebpackHelpers = require("@hotwired/stimulus-webpack-helpers");
 
 var _controllers = _interopRequireDefault(require("./webpack/loader!@symfony/stimulus-bridge/controllers.json"));
 
@@ -27,7 +27,7 @@ function startStimulusApp(context) {
   var application = _stimulus.Application.start();
 
   if (context) {
-    application.load((0, _webpackHelpers.definitionsFromContext)(context));
+    application.load((0, _stimulusWebpackHelpers.definitionsFromContext)(context));
   }
 
   var _loop = function _loop(controllerName) {

--- a/dist/webpack/create-controllers-module.js
+++ b/dist/webpack/create-controllers-module.js
@@ -82,7 +82,7 @@ module.exports = function createControllersModule(config) {
   }
 
   if (hasLazyControllers) {
-    controllerContents = "import { Controller } from 'stimulus';\n".concat(controllerContents);
+    controllerContents = "import { Controller } from '@hotwired/stimulus';\n".concat(controllerContents);
   }
 
   return {

--- a/dist/webpack/lazy-controller-loader.js
+++ b/dist/webpack/lazy-controller-loader.js
@@ -88,7 +88,7 @@ module.exports = function (source, sourceMap) {
   }
 
   var exportName = typeof loaderOptions["export"] !== 'undefined' ? loaderOptions["export"] : 'default';
-  var finalSource = "import { Controller } from 'stimulus';\nconst controller = ".concat(generateLazyController(this.resource, 0, exportName), ";\nexport { controller as ").concat(exportName, " };"); // The source Map cannot be passed when lazy, as the sourceMap won't
+  var finalSource = "import { Controller } from '@hotwired/stimulus';\nconst controller = ".concat(generateLazyController(this.resource, 0, exportName), ";\nexport { controller as ").concat(exportName, " };"); // The source Map cannot be passed when lazy, as the sourceMap won't
   // map up to the new source. In theory, this is fixable, but I'm
   // not entirely sure how.
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
         "test": "webpack --config test/webpack.config.js && jest"
     },
     "peerDependencies": {
-        "stimulus": "^2.0"
+        "@hotwired/stimulus": "^3.0"
     },
     "dependencies": {
+        "@hotwired/stimulus-webpack-helpers": "^1.0.1",
         "acorn": "^8.0.5",
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
@@ -24,9 +25,10 @@
         "@babel/cli": "^7.12.1",
         "@babel/core": "^7.12.3",
         "@babel/preset-env": "^7.12.7",
+        "@hotwired/stimulus": "^3.0",
         "@symfony/mock-module": "file:test/fixtures/module",
         "@symfony/stimulus-testing": "^1.0.0",
-        "stimulus": "^2.0",
+        "prettier": "^2.2.0",
         "webpack": "^5.11.1",
         "webpack-cli": "^4.3.0"
     },

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@
 
 'use strict';
 
-import { Application } from 'stimulus';
-import { definitionsFromContext } from 'stimulus/webpack-helpers';
+import { Application } from '@hotwired/stimulus';
+import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers';
 
 // The @symfony/stimulus-bridge/controllers.json should be changed
 // to point to the real controllers.json file via a Webpack alias

--- a/src/webpack/create-controllers-module.js
+++ b/src/webpack/create-controllers-module.js
@@ -96,7 +96,7 @@ ${generateLazyController(controllerMain, 6)}
     }
 
     if (hasLazyControllers) {
-        controllerContents = `import { Controller } from 'stimulus';\n${controllerContents}`;
+        controllerContents = `import { Controller } from '@hotwired/stimulus';\n${controllerContents}`;
     }
 
     return {

--- a/src/webpack/lazy-controller-loader.js
+++ b/src/webpack/lazy-controller-loader.js
@@ -74,7 +74,7 @@ module.exports = function (source, sourceMap) {
 
     const exportName = typeof loaderOptions.export !== 'undefined' ? loaderOptions.export : 'default';
 
-    const finalSource = `import { Controller } from 'stimulus';
+    const finalSource = `import { Controller } from '@hotwired/stimulus';
 const controller = ${generateLazyController(this.resource, 0, exportName)};
 export { controller as ${exportName} };`;
 

--- a/test/fixtures/module/dist/controller.js
+++ b/test/fixtures/module/dist/controller.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
     connect() {}

--- a/test/webpack/create-controllers-module.test.js
+++ b/test/webpack/create-controllers-module.test.js
@@ -69,7 +69,7 @@ describe('createControllersModule', () => {
             const config = require('../fixtures/lazy-no-autoimport.json');
             expect(createControllersModule(config).finalSource).toEqual(
                 `
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 export default {
   'symfony--mock-module--mock': new Promise((resolve, reject) => resolve({ default:
       (function() {

--- a/test/webpack/generate-lazy-controller.test.js
+++ b/test/webpack/generate-lazy-controller.test.js
@@ -17,7 +17,7 @@ describe('generateLazyControllerModule', () => {
     describe('generateLazyController()', () => {
         it('must return a functional ES5 class', () => {
             const controllerCode =
-                "const Controller = require('stimulus');\n" +
+                "const Controller = require('@hotwired/stimulus');\n" +
                 // this, for some reason, is undefined in a test but populated in a real situation
                 // this avoid an explosion since it is undefined here
                 'Controller.prototype = {};\n' +
@@ -35,7 +35,7 @@ describe('generateLazyControllerModule', () => {
 
         it('must return a functional ES5 class on Windows', () => {
             const controllerCode =
-                "const Controller = require('stimulus');\n" +
+                "const Controller = require('@hotwired/stimulus');\n" +
                 // this, for some reason, is undefined in a test but populated in a real situation
                 // this avoid an explosion since it is undefined here
                 'Controller.prototype = {};\n' +
@@ -56,7 +56,7 @@ describe('generateLazyControllerModule', () => {
 
         it('must use the correct, named export', () => {
             const controllerCode =
-                "const Controller = require('stimulus');\n" +
+                "const Controller = require('@hotwired/stimulus');\n" +
                 // this, for some reason, is undefined in a test but populated in a real situation
                 // this avoid an explosion since it is undefined here
                 'Controller.prototype = {};\n' +


### PR DESCRIPTION
Adds support for Stimulus 3. Unless we get fancy (which we could I think, but it's a bit unnatural), this will require a new major release of this library.

TODOs:

* [x] `@symfony/stimulus-testing` needs to be updated to work with Stimulus 3
* [x] Fix tests (depends on above)

Before a tag, we need to

* [ ] Upgrade the symfony/ux packages to support Stimulus v3.