### PR TITLE
Adding `core-js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dependencies": {
         "acorn": "^8.0.5",
         "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
+        "schema-utils": "^3.0.0",
+        "core-js": "^3.19.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.12.1",


### PR DESCRIPTION
Is this the right fix for https://github.com/symfony/stimulus-bridge/issues/49 and https://github.com/symfony/stimulus-bridge/issues/47 ? Thanks to @graceman9 and @Kocal, I solved it by doing `npm install --save core-js@3.19.0`.
So I'm **guessing** it might be better to add it here right away.

Closes https://github.com/symfony/stimulus-bridge/issues/49