### PR TITLE
Lazy controller loader: generate true ES6 class

### DIFF
--- a/dist/webpack/lazy-controller-loader.js
+++ b/dist/webpack/lazy-controller-loader.js
@@ -31,26 +31,22 @@ var schemaUtils__namespace = /*#__PURE__*/_interopNamespace(schemaUtils);
 function generateLazyController (controllerPath, indentationSpaces, exportName = 'default') {
     const spaces = ' '.repeat(indentationSpaces);
     return `${spaces}(function() {
-${spaces}    function LazyController(context) {
-${spaces}        this.__stimulusLazyController = true;
-${spaces}        Controller.call(this, context);
-${spaces}    }
-${spaces}    LazyController.prototype = Object.create(Controller && Controller.prototype, {
-${spaces}        constructor: { value: LazyController, writable: true, configurable: true }
-${spaces}    });
-${spaces}    Object.setPrototypeOf(LazyController, Controller);
-${spaces}    LazyController.prototype.initialize = function() {
-${spaces}        var _this = this;
-${spaces}        if (this.application.controllers.find(function(controller) {
-${spaces}            return controller.identifier === _this.identifier && controller.__stimulusLazyController;
-${spaces}        })) {
-${spaces}            return;
+${spaces}    return class LazyController extends Controller {
+${spaces}        constructor(context) {
+${spaces}            super(context);
+${spaces}            this.__stimulusLazyController = true;
 ${spaces}        }
-${spaces}        import('${controllerPath.replace(/\\/g, '\\\\')}').then(function(controller) {
-${spaces}            _this.application.register(_this.identifier, controller.${exportName});
-${spaces}        });
+${spaces}        initialize() {
+${spaces}            if (this.application.controllers.find((controller) => {
+${spaces}                return controller.identifier === this.identifier && controller.__stimulusLazyController;
+${spaces}            })) {
+${spaces}                return;
+${spaces}            }
+${spaces}            import('${controllerPath.replace(/\\/g, '\\\\')}').then((controller) => {
+${spaces}                this.application.register(this.identifier, controller.${exportName});
+${spaces}            });
+${spaces}        }
 ${spaces}    }
-${spaces}    return LazyController;
 ${spaces}})()`;
 }
 

--- a/dist/webpack/loader.js
+++ b/dist/webpack/loader.js
@@ -9,26 +9,22 @@ var LoaderDependency__default = /*#__PURE__*/_interopDefaultLegacy(LoaderDepende
 function generateLazyController (controllerPath, indentationSpaces, exportName = 'default') {
     const spaces = ' '.repeat(indentationSpaces);
     return `${spaces}(function() {
-${spaces}    function LazyController(context) {
-${spaces}        this.__stimulusLazyController = true;
-${spaces}        Controller.call(this, context);
-${spaces}    }
-${spaces}    LazyController.prototype = Object.create(Controller && Controller.prototype, {
-${spaces}        constructor: { value: LazyController, writable: true, configurable: true }
-${spaces}    });
-${spaces}    Object.setPrototypeOf(LazyController, Controller);
-${spaces}    LazyController.prototype.initialize = function() {
-${spaces}        var _this = this;
-${spaces}        if (this.application.controllers.find(function(controller) {
-${spaces}            return controller.identifier === _this.identifier && controller.__stimulusLazyController;
-${spaces}        })) {
-${spaces}            return;
+${spaces}    return class LazyController extends Controller {
+${spaces}        constructor(context) {
+${spaces}            super(context);
+${spaces}            this.__stimulusLazyController = true;
 ${spaces}        }
-${spaces}        import('${controllerPath.replace(/\\/g, '\\\\')}').then(function(controller) {
-${spaces}            _this.application.register(_this.identifier, controller.${exportName});
-${spaces}        });
+${spaces}        initialize() {
+${spaces}            if (this.application.controllers.find((controller) => {
+${spaces}                return controller.identifier === this.identifier && controller.__stimulusLazyController;
+${spaces}            })) {
+${spaces}                return;
+${spaces}            }
+${spaces}            import('${controllerPath.replace(/\\/g, '\\\\')}').then((controller) => {
+${spaces}                this.application.register(this.identifier, controller.${exportName});
+${spaces}            });
+${spaces}        }
 ${spaces}    }
-${spaces}    return LazyController;
 ${spaces}})()`;
 }
 

--- a/src/webpack/generate-lazy-controller.ts
+++ b/src/webpack/generate-lazy-controller.ts
@@ -19,25 +19,21 @@ export default function(controllerPath: string, indentationSpaces: number, expor
     const spaces = ' '.repeat(indentationSpaces);
 
     return `${spaces}(function() {
-${spaces}    function LazyController(context) {
-${spaces}        this.__stimulusLazyController = true;
-${spaces}        Controller.call(this, context);
-${spaces}    }
-${spaces}    LazyController.prototype = Object.create(Controller && Controller.prototype, {
-${spaces}        constructor: { value: LazyController, writable: true, configurable: true }
-${spaces}    });
-${spaces}    Object.setPrototypeOf(LazyController, Controller);
-${spaces}    LazyController.prototype.initialize = function() {
-${spaces}        var _this = this;
-${spaces}        if (this.application.controllers.find(function(controller) {
-${spaces}            return controller.identifier === _this.identifier && controller.__stimulusLazyController;
-${spaces}        })) {
-${spaces}            return;
+${spaces}    return class LazyController extends Controller {
+${spaces}        constructor(context) {
+${spaces}            super(context);
+${spaces}            this.__stimulusLazyController = true;
 ${spaces}        }
-${spaces}        import('${controllerPath.replace(/\\/g, '\\\\')}').then(function(controller) {
-${spaces}            _this.application.register(_this.identifier, controller.${exportName});
-${spaces}        });
+${spaces}        initialize() {
+${spaces}            if (this.application.controllers.find((controller) => {
+${spaces}                return controller.identifier === this.identifier && controller.__stimulusLazyController;
+${spaces}            })) {
+${spaces}                return;
+${spaces}            }
+${spaces}            import('${controllerPath.replace(/\\/g, '\\\\')}').then((controller) => {
+${spaces}                this.application.register(this.identifier, controller.${exportName});
+${spaces}            });
+${spaces}        }
 ${spaces}    }
-${spaces}    return LazyController;
 ${spaces}})()`;
 }

--- a/test/webpack/create-controllers-module.test.ts
+++ b/test/webpack/create-controllers-module.test.ts
@@ -80,26 +80,22 @@ import { Controller } from '@hotwired/stimulus';
 export default {
   'symfony--mock-module--mock': new Promise((resolve, reject) => resolve({ default:
       (function() {
-          function LazyController(context) {
-              this.__stimulusLazyController = true;
-              Controller.call(this, context);
-          }
-          LazyController.prototype = Object.create(Controller && Controller.prototype, {
-              constructor: { value: LazyController, writable: true, configurable: true }
-          });
-          Object.setPrototypeOf(LazyController, Controller);
-          LazyController.prototype.initialize = function() {
-              var _this = this;
-              if (this.application.controllers.find(function(controller) {
-                  return controller.identifier === _this.identifier && controller.__stimulusLazyController;
-              })) {
-                  return;
+          return class LazyController extends Controller {
+              constructor(context) {
+                  super(context);
+                  this.__stimulusLazyController = true;
               }
-              import('@symfony/mock-module/dist/controller.js').then(function(controller) {
-                  _this.application.register(_this.identifier, controller.default);
-              });
+              initialize() {
+                  if (this.application.controllers.find((controller) => {
+                      return controller.identifier === this.identifier && controller.__stimulusLazyController;
+                  })) {
+                      return;
+                  }
+                  import('@symfony/mock-module/dist/controller.js').then((controller) => {
+                      this.application.register(this.identifier, controller.default);
+                  });
+              }
           }
-          return LazyController;
       })()
   })),
 };

--- a/test/webpack/generate-lazy-controller.test.ts
+++ b/test/webpack/generate-lazy-controller.test.ts
@@ -15,13 +15,10 @@ import { isNode } from '@babel/types';
 
 describe('generateLazyControllerModule', () => {
     describe('generateLazyController()', () => {
-        it('must return a functional ES5 class', () => {
+        it('must return a functional ES6 class', () => {
             const controllerCode =
-                "const Controller = require('@hotwired/stimulus');\n" +
-                // this, for some reason, is undefined in a test but populated in a real situation
-                // this avoid an explosion since it is undefined here
-                'Controller.prototype = {};\n' +
-                generateLazyController('@symfony/some-module/dist/controller.js');
+                "const { Controller } = require('@hotwired/stimulus');\n" +
+                generateLazyController('@symfony/some-module/dist/controller.js', 0);
             const result = parse(controllerCode, {
                 sourceType: 'module',
             });
@@ -29,17 +26,14 @@ describe('generateLazyControllerModule', () => {
 
             const lazyControllerClass = eval(`${controllerCode}`);
             // if all goes correctly, the prototype should have a Controller key
-            expect(Object.getPrototypeOf(lazyControllerClass)).toHaveProperty('Controller');
-            expect(controllerCode).toContain('_this.application.register(_this.identifier, controller.default)');
+            expect(Object.getPrototypeOf(lazyControllerClass)).toHaveProperty('targets');
+            expect(controllerCode).toContain('this.application.register(this.identifier, controller.default)');
         });
 
         it('must return a functional ES5 class on Windows', () => {
             const controllerCode =
-                "const Controller = require('@hotwired/stimulus');\n" +
-                // this, for some reason, is undefined in a test but populated in a real situation
-                // this avoid an explosion since it is undefined here
-                'Controller.prototype = {};\n' +
-                generateLazyController('C:\\\\path\\to\\file.js');
+                "const { Controller } = require('@hotwired/stimulus');\n" +
+                generateLazyController('C:\\\\path\\to\\file.js', 0);
             const result = parse(controllerCode, {
                 sourceType: 'module',
             });
@@ -56,17 +50,14 @@ describe('generateLazyControllerModule', () => {
 
         it('must use the correct, named export', () => {
             const controllerCode =
-                "const Controller = require('@hotwired/stimulus');\n" +
-                // this, for some reason, is undefined in a test but populated in a real situation
-                // this avoid an explosion since it is undefined here
-                'Controller.prototype = {};\n' +
+                "const { Controller } = require('@hotwired/stimulus');\n" +
                 generateLazyController('@symfony/some-module/dist/controller.js', 0, 'CustomController');
             const result = parse(controllerCode, {
                 sourceType: 'module',
             });
             expect(isNode(result)).toBeTruthy();
             expect(controllerCode).toContain(
-                '_this.application.register(_this.identifier, controller.CustomController)'
+                'this.application.register(this.identifier, controller.CustomController)'
             );
         });
     });

--- a/test/webpack/lazy-controller-loader.test.ts
+++ b/test/webpack/lazy-controller-loader.test.ts
@@ -11,7 +11,7 @@
 
 import lazyControllerLoader from '../../src/webpack/lazy-controller-loader';
 
-function callLoader(src, startingSourceMap = '', query = '') {
+function callLoader(src: string, startingSourceMap = '', query = '') {
     const loaderThis = {
         emittedErrors: [],
         executedCallback: null,
@@ -47,7 +47,7 @@ describe('lazyControllerLoader', () => {
     it('exports a lazy controller', () => {
         const src = "/* stimulusFetch: 'lazy' */ export default class extends Controller {}";
         // look for a little bit of the lazy controller code
-        expect(callLoader(src).content).toContain('function LazyController');
+        expect(callLoader(src).content).toContain('class LazyController');
         // unfortunately, we cannot pass along sourceMap info since we changed the source
         expect(callLoader(src, 'source_map_contents').sourceMap).toBeUndefined();
         expect(callLoader(src).errors).toHaveLength(0);
@@ -66,14 +66,14 @@ describe('lazyControllerLoader', () => {
     it('reads ?lazy option', () => {
         const src = 'export default class extends Controller {}';
         const results = callLoader(src, '', '?lazy=true');
-        expect(results.content).toContain('function LazyController');
+        expect(results.content).toContain('class LazyController');
         expect(results.errors).toHaveLength(0);
     });
 
     it('reads ?lazy and it wins over comments', () => {
         const src = "/* stimulusFetch: 'eager' */ export default class extends Controller {}";
         const results = callLoader(src, '', '?lazy=true');
-        expect(results.content).toContain('function LazyController');
+        expect(results.content).toContain('class LazyController');
         expect(results.errors).toHaveLength(0);
     });
 
@@ -81,7 +81,7 @@ describe('lazyControllerLoader', () => {
         const src = 'const MyController = class extends Controller {}; export { MyController };';
         const results = callLoader(src, '', '?lazy=true&export=MyController');
         // check that the results are lazy
-        expect(results.content).toContain('function LazyController');
+        expect(results.content).toContain('class LazyController');
         // check named export
         expect(results.content).toContain('export { controller as MyController };');
         expect(results.errors).toHaveLength(0);


### PR DESCRIPTION
One big, but kind of hidden change with Stimulus 3 is that IE11 support/ES5 has been dropped. This means, for example, that the Stimulus' classes are no longer transpiled from ES6 to ES5: they remain as true ES6 classes.

For the lazy controller, we need to do the same because you cannot extend an ES6 class with an ES5 class.  But also, since we're no longer support ES5, this just generates better code :) 