### PR TITLE
Activating "debug" mode for Stimulus for dev builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 3.1.0
+
+* Automatically enabled Stimulus's "debug" mode when doing a dev build. You will
+  now, while developing, see debugging information in your browser's console log!
+  See #65.
+
 ## 3.0.0
 
 Dropped support for `stimulus` 2.0, in favor of `@hotwired/stimulus` version 3.

--- a/dist/index.js
+++ b/dist/index.js
@@ -31,6 +31,9 @@ function identifierForContextKey(key) {
 
 function startStimulusApp(context) {
     const application = Application.start();
+    if (process.env.NODE_ENV === 'development') {
+        application.debug = true;
+    }
     if (context) {
         application.load(definitionsFromContext(context));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ import symfonyControllers from './webpack/loader!@symfony/stimulus-bridge/contro
 export function startStimulusApp(context: any) {
     const application = Application.start();
 
+    if (process.env.NODE_ENV === 'development') {
+        application.debug = true;
+    }
+
     if (context) {
         application.load(definitionsFromContext(context));
     }


### PR DESCRIPTION
Hi!

Well... this was such an easy win, we should have done it awhile ago :).

For a "dev" build, this activates Stimulus's debug mode, which outputs a lot of information to the log. Here is an example of a page with a single controller... and then after I activate an action on that controller:

<img width="233" alt="Screen Shot 2022-04-19 at 10 09 53 AM" src="https://user-images.githubusercontent.com/121003/164023350-f0086b9b-afaa-47bb-b5f2-5e73e4f5da48.png">
 
When running `yarn encore production` (or `npm run encore production`), debug mode will be disabled. Heck, Weback is SO cool that, when building for production, the entire new `if` statement is omitted (i.e. this adds 0 extra bytes to production builds).