### PR TITLE
Making it possible to add a "default" import for shorter controller name

### DIFF
--- a/dist/webpack/loader.js
+++ b/dist/webpack/loader.js
@@ -49,7 +49,13 @@ function createControllersModule(config) {
         }
         for (const controllerName in config.controllers[packageName]) {
             const controllerReference = packageName + '/' + controllerName;
-            const controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+            let controllerNormalizedName;
+            if (controllerName === 'default') {
+                controllerNormalizedName = packageName.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+            }
+            else {
+                controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+            }
             if ('undefined' === typeof packageConfig.symfony.controllers[controllerName]) {
                 throw new Error('Controller "' + controllerReference + '" does not exist in the package and cannot be compiled.');
             }

--- a/src/webpack/create-controllers-module.ts
+++ b/src/webpack/create-controllers-module.ts
@@ -11,7 +11,7 @@
 
 import generateLazyController from './generate-lazy-controller';
 
-export default function createControllersModule(config) {
+export default function createControllersModule(config: any) {
     let controllerContents = 'export default {';
     let autoImportContents = '';
     let hasLazyControllers = false;
@@ -40,7 +40,14 @@ export default function createControllersModule(config) {
         for (const controllerName in config.controllers[packageName]) {
             const controllerReference = packageName + '/' + controllerName;
             // Normalize the controller name: remove the initial @ and use Stimulus format
-            const controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+
+            let controllerNormalizedName: string;
+            // allow a "default" controller which takes on the package name
+            if (controllerName === 'default') {
+                controllerNormalizedName = packageName.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+            } else {
+                controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+            }
 
             // Find package config for the controller
             if ('undefined' === typeof packageConfig.symfony.controllers[controllerName]) {

--- a/test/fixtures/default-import-name.json
+++ b/test/fixtures/default-import-name.json
@@ -1,0 +1,11 @@
+{
+    "controllers": {
+        "@symfony/mock-module": {
+            "default": {
+                "fetch": "eager",
+                "enabled": true
+            }
+        }
+    },
+    "entrypoints": []
+}

--- a/test/fixtures/module/package.json
+++ b/test/fixtures/module/package.json
@@ -10,6 +10,11 @@
                 "importedStyles": {
                     "@symfony/mock-module/dist/style.css": true
                 }
+            },
+            "default": {
+                "main": "dist/default_controller.js",
+                "webpackMode": "eager",
+                "enabled": true
             }
         }
     }

--- a/test/webpack/create-controllers-module.test.ts
+++ b/test/webpack/create-controllers-module.test.ts
@@ -103,4 +103,14 @@ export default {
             );
         });
     });
+
+    describe('default-import-name.json', () => {
+        it('must register a controller with no second part of the name', () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const config = require('../fixtures/default-import-name.json');
+            expect(createControllersModule(config).finalSource).toEqual(
+                "export default {\n  'symfony--mock-module': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/default_controller.js'),\n};"
+            );
+        });
+    });
 });


### PR DESCRIPTION
Right now, the UX controller names have the form `symfony/ux-typed/typed` (well, technically `symfony--ux-typed--typed`, but `stimulus_controller()` normalizes for you).

Anyways, most UX components only ship with 1 controller... and `symfony/ux-typed/typed` seems unnecessarily long. This PR allows for a package to define a controller called `default` in its package.json - e.g. right here: https://github.com/symfony/ux/blob/09c9effcc2582d4de0907c9e12c35afa313433ae/src/Typed/Resources/assets/package.json#L8

When this happens, the final package name would be just the package name: `symfony/ux-typed`

Cheers!