### PR TITLE
Allowing the controller name to be overridden by the package or the user

### DIFF
--- a/dist/webpack/loader.js
+++ b/dist/webpack/loader.js
@@ -49,7 +49,6 @@ function createControllersModule(config) {
         }
         for (const controllerName in config.controllers[packageName]) {
             const controllerReference = packageName + '/' + controllerName;
-            const controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
             if ('undefined' === typeof packageConfig.symfony.controllers[controllerName]) {
                 throw new Error('Controller "' + controllerReference + '" does not exist in the package and cannot be compiled.');
             }
@@ -77,6 +76,13 @@ new Promise((resolve, reject) => resolve({ default:
 ${generateLazyController(controllerMain, 6)}
   }))
                 `.trim();
+            }
+            let controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+            if ('undefined' !== typeof controllerPackageConfig.name) {
+                controllerNormalizedName = controllerPackageConfig.name;
+            }
+            if ('undefined' !== typeof controllerUserConfig.name) {
+                controllerNormalizedName = controllerUserConfig.name;
             }
             controllerContents += `\n  '${controllerNormalizedName}': ${moduleValueContents},`;
             for (const autoimport in controllerUserConfig.autoimport || []) {

--- a/src/webpack/create-controllers-module.ts
+++ b/src/webpack/create-controllers-module.ts
@@ -39,8 +39,6 @@ export default function createControllersModule(config) {
 
         for (const controllerName in config.controllers[packageName]) {
             const controllerReference = packageName + '/' + controllerName;
-            // Normalize the controller name: remove the initial @ and use Stimulus format
-            const controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
 
             // Find package config for the controller
             if ('undefined' === typeof packageConfig.symfony.controllers[controllerName]) {
@@ -83,6 +81,16 @@ new Promise((resolve, reject) => resolve({ default:
 ${generateLazyController(controllerMain, 6)}
   }))
                 `.trim();
+            }
+
+            // Normalize the controller name: remove the initial @ and use Stimulus format
+            let controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
+            // allow the package or user config to override name
+            if ('undefined' !== typeof controllerPackageConfig.name) {
+                controllerNormalizedName = controllerPackageConfig.name;
+            }
+            if ('undefined' !== typeof controllerUserConfig.name) {
+                controllerNormalizedName = controllerUserConfig.name;
             }
 
             controllerContents += `\n  '${controllerNormalizedName}': ${moduleValueContents},`;

--- a/test/fixtures/load-named-controller.json
+++ b/test/fixtures/load-named-controller.json
@@ -1,0 +1,11 @@
+{
+    "controllers": {
+        "@symfony/mock-module": {
+            "mock_named": {
+                "fetch": "eager",
+                "enabled": true
+            }
+        }
+    },
+    "entrypoints": []
+}

--- a/test/fixtures/module/package.json
+++ b/test/fixtures/module/package.json
@@ -10,6 +10,12 @@
                 "importedStyles": {
                     "@symfony/mock-module/dist/style.css": true
                 }
+            },
+            "mock_named": {
+                "main": "dist/named_controller.js",
+                "name": "custom_name",
+                "webpackMode": "eager",
+                "enabled": true
             }
         }
     }

--- a/test/fixtures/override-name.json
+++ b/test/fixtures/override-name.json
@@ -1,0 +1,12 @@
+{
+    "controllers": {
+        "@symfony/mock-module": {
+            "mock": {
+                "name": "overridden_name",
+                "fetch": "eager",
+                "enabled": true
+            }
+        }
+    },
+    "entrypoints": []
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,6 +14,7 @@ import { startStimulusApp } from './dist/index';
 describe('startStimulusApp', () => {
     it('must start the app', async () => {
         const app = startStimulusApp();
+        app.debug = false;
 
         // Wait for controllers to be loaded
         await app.start();

--- a/test/webpack/create-controllers-module.test.ts
+++ b/test/webpack/create-controllers-module.test.ts
@@ -103,4 +103,24 @@ export default {
             );
         });
     });
+
+    describe('load-named-controller.json', () => {
+        it('must register the custom name from package.json', () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const config = require('../fixtures/load-named-controller.json');
+            expect(createControllersModule(config).finalSource).toEqual(
+                "export default {\n  'custom_name': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/named_controller.js'),\n};"
+            );
+        });
+    });
+
+    describe('override-name.json', () => {
+        it('must return file with no autoimport', () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const config = require('../fixtures/override-name.json');
+            expect(createControllersModule(config).finalSource).toEqual(
+                "export default {\n  'overridden_name': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/controller.js'),\n};"
+            );
+        });
+    });
 });


### PR DESCRIPTION
This is needed for live components, where the controller name needs to be simply `live`... else it will be super annoying to use :). 

Allowing the user to also override the controller name... isn't really needed... but if the user does this, I think they know they are on their own.


This COULD actually replace #69... as a package could add, for example, `name: 'symfony/ux-typed'` to change the name to a shorter version.