### PR TITLE
Normalizing custom names "/" to "--" like normal controller names

### DIFF
--- a/dist/webpack/loader.js
+++ b/dist/webpack/loader.js
@@ -79,10 +79,10 @@ ${generateLazyController(controllerMain, 6)}
             }
             let controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
             if ('undefined' !== typeof controllerPackageConfig.name) {
-                controllerNormalizedName = controllerPackageConfig.name;
+                controllerNormalizedName = controllerPackageConfig.name.replace(/\//g, '--');
             }
             if ('undefined' !== typeof controllerUserConfig.name) {
-                controllerNormalizedName = controllerUserConfig.name;
+                controllerNormalizedName = controllerUserConfig.name.replace(/\//g, '--');
             }
             controllerContents += `\n  '${controllerNormalizedName}': ${moduleValueContents},`;
             for (const autoimport in controllerUserConfig.autoimport || []) {

--- a/src/webpack/create-controllers-module.ts
+++ b/src/webpack/create-controllers-module.ts
@@ -11,7 +11,7 @@
 
 import generateLazyController from './generate-lazy-controller';
 
-export default function createControllersModule(config) {
+export default function createControllersModule(config: any) {
     let controllerContents = 'export default {';
     let autoImportContents = '';
     let hasLazyControllers = false;
@@ -87,10 +87,10 @@ ${generateLazyController(controllerMain, 6)}
             let controllerNormalizedName = controllerReference.substr(1).replace(/_/g, '-').replace(/\//g, '--');
             // allow the package or user config to override name
             if ('undefined' !== typeof controllerPackageConfig.name) {
-                controllerNormalizedName = controllerPackageConfig.name;
+                controllerNormalizedName = controllerPackageConfig.name.replace(/\//g, '--');
             }
             if ('undefined' !== typeof controllerUserConfig.name) {
-                controllerNormalizedName = controllerUserConfig.name;
+                controllerNormalizedName = controllerUserConfig.name.replace(/\//g, '--');
             }
 
             controllerContents += `\n  '${controllerNormalizedName}': ${moduleValueContents},`;

--- a/test/fixtures/module/package.json
+++ b/test/fixtures/module/package.json
@@ -13,7 +13,7 @@
             },
             "mock_named": {
                 "main": "dist/named_controller.js",
-                "name": "custom_name",
+                "name": "foo/custom_name",
                 "webpackMode": "eager",
                 "enabled": true
             }

--- a/test/fixtures/override-name.json
+++ b/test/fixtures/override-name.json
@@ -2,7 +2,7 @@
     "controllers": {
         "@symfony/mock-module": {
             "mock": {
-                "name": "overridden_name",
+                "name": "foo/overridden_name",
                 "fetch": "eager",
                 "enabled": true
             }

--- a/test/webpack/create-controllers-module.test.ts
+++ b/test/webpack/create-controllers-module.test.ts
@@ -105,21 +105,21 @@ export default {
     });
 
     describe('load-named-controller.json', () => {
-        it('must register the custom name from package.json', () => {
+        it('must register the custom name from package\'s package.json', () => {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const config = require('../fixtures/load-named-controller.json');
             expect(createControllersModule(config).finalSource).toEqual(
-                "export default {\n  'custom_name': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/named_controller.js'),\n};"
+                "export default {\n  'foo--custom_name': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/named_controller.js'),\n};"
             );
         });
     });
 
     describe('override-name.json', () => {
-        it('must return file with no autoimport', () => {
+        it('must use the overridden "name" from user\'s config', () => {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const config = require('../fixtures/override-name.json');
             expect(createControllersModule(config).finalSource).toEqual(
-                "export default {\n  'overridden_name': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/controller.js'),\n};"
+                "export default {\n  'foo--overridden_name': import(/* webpackMode: \"eager\" */ '@symfony/mock-module/dist/controller.js'),\n};"
             );
         });
     });


### PR DESCRIPTION
This was an oversight when I did #70. I believe we don't ever want `/` in the controller name. Now, if you set `'name': 'symfony/ux-typed'`, it will normalize to `symfony--ux-typed`. This is important because `{{ stimulus_controller('symfony/ux-typed')` already normalizes to `symfony--ux-typed`.

Cheers!