### PR TITLE
Add missing `@babel/plugin-proposal-class-properties` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.15.8",
+        "@babel/plugin-proposal-class-properties": "^7.15.8",
         "@babel/preset-env": "^7.15.8",
         "@babel/preset-typescript": "^7.15.0",
         "@hotwired/stimulus": "^3.0",
@@ -92,5 +93,6 @@
         "dist/",
         "controllers.json",
         "lazy-controller-loader.js"
-    ]
+    ],
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
I was not able to run tests after cloning the repository and installing dependencies, because `@babel/plugin-proposal-class-properties` is missing:
```
➜  symfony-stimulus-bridge git:(main) yarn test
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager

yarn run v1.22.22
$ yarn run webpack --config test/webpack.config.js && yarn run jest
$ /Users/kocal/workspace-os/symfony-stimulus-bridge/node_modules/.bin/webpack --config test/webpack.config.js
asset index.js 94.9 KiB [emitted] (name: main) 1 related asset
runtime modules 670 bytes 3 modules
cacheable modules 88.7 KiB
  modules by path ./node_modules/ 87 KiB
    ./node_modules/@hotwired/stimulus/dist/stimulus.js 86.6 KiB [built] [code generated]
    ./node_modules/@symfony/mock-module/dist/controller.js 357 bytes [built] [code generated]
  ./dist/index.js 1.59 KiB [built] [code generated]
  ./dist/webpack/loader.js!./test/controllers.json 133 bytes [built] [code generated]
webpack 5.97.1 compiled successfully in 133 ms
$ /Users/kocal/workspace-os/symfony-stimulus-bridge/node_modules/.bin/jest
(node:70050) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:70049) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:70052) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:70053) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:70051) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 FAIL  test/webpack/create-controllers-module.test.ts
  ● Test suite failed to run

    Cannot find module '@babel/plugin-proposal-class-properties'
    Require stack:
    - /Users/kocal/workspace-os/symfony-stimulus-bridge/node_modules/@babel/core/lib/config/files/plugins.js
    - /Users/kocal/workspace-os/symfony-stimulus-bridge/node_modules/@babel/core/lib/config/files/index.js
    - /Users/kocal/workspace-os/symfony-stimulus-bridge/node_modules/@babel/core/lib/index.js
    - /Users/kocal/workspace-os/symfony-stimulus-bridge/node_modules/jest-snapshot/build/InlineSnapshots.js
    - Did you mean "@babel/plugin-transform-class-properties"?

    Make sure that all the Babel plugins and presets you are using
    are defined as dependencies or devDependencies in your package.json
    file. It's possible that the missing plugin is loaded by a preset
    you are using that forgot to add the plugin to its dependencies: you
    can workaround this problem by explicitly adding the missing package
    to your top-level package.json.

      at tryRequireResolve (node_modules/@babel/core/src/config/files/plugins.ts:140:36)
      at resolveStandardizedNameForRequire (node_modules/@babel/core/src/config/files/plugins.ts:168:19)
      at resolvePlugin (node_modules/@babel/core/src/config/files/plugins.ts:196:12)
      at resolver (node_modules/@babel/core/src/config/files/plugins.ts:38:32)
          at loadPlugin.next (<anonymous>)
      at createDescriptor (node_modules/@babel/core/src/config/config-descriptors.ts:326:35)
          at createDescriptor.next (<anonymous>)
      at evaluateSync (node_modules/gensync/index.js:251:28)
      at node_modules/gensync/index.js:31:34
          at Array.map (<anonymous>)
      at Function.sync (node_modules/gensync/index.js:31:22)
      at Function.all (node_modules/gensync/index.js:210:24)
      at createDescriptors (node_modules/@babel/core/src/config/config-descriptors.ts:267:38)
          at createDescriptors.next (<anonymous>)
      at fn (node_modules/@babel/core/src/config/config-descriptors.ts:257:17)
          at createPluginDescriptors.next (<anonymous>)
      at plugins (node_modules/@babel/core/src/gensync-utils/functional.ts:18:46)
      at mergeChainOpts (node_modules/@babel/core/src/config/config-chain.ts:724:34)
          at mergeChainOpts.next (<anonymous>)
      at loadFileChainWalker (node_modules/@babel/core/src/config/config-chain.ts:661:14)
          at chainWalker.next (<anonymous>)
      at loadFileChain (node_modules/@babel/core/src/config/config-chain.ts:398:24)
          at loadFileChain.next (<anonymous>)
      at buildRootChain (node_modules/@babel/core/src/config/config-chain.ts:242:31)
          at buildRootChain.next (<anonymous>)
      at loadPrivatePartialConfig (node_modules/@babel/core/src/config/partial.ts:111:44)
          at loadPrivatePartialConfig.next (<anonymous>)
      at loadPartialConfig (node_modules/@babel/core/src/config/partial.ts:170:12)
          at loadPartialConfig.next (<anonymous>)
      at evaluateSync (node_modules/gensync/index.js:251:28)
      at fn (node_modules/gensync/index.js:89:14)
      at stopHiding - secret - don't use this - v1 (node_modules/@babel/core/src/errors/rewrite-stack-trace.ts:99:14)
      at loadPartialConfigSync (node_modules/@babel/core/src/config/index.ts:50:60)
      at loadPartialConfig (node_modules/@babel/core/src/config/index.ts:69:14)
      at ScriptTransformer._getCacheKey (node_modules/@jest/transform/build/ScriptTransformer.js:281:41)
      at ScriptTransformer._getFileCachePath (node_modules/@jest/transform/build/ScriptTransformer.js:352:27)
      at ScriptTransformer.transformSource (node_modules/@jest/transform/build/ScriptTransformer.js:595:32)
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:765:40)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:822:19)

```