### PR TITLE
Fix lazy-controller detection when controller contain static properties (update `acorn` ECMAScript version)

### DIFF
--- a/dist/webpack/lazy-controller-loader.js
+++ b/dist/webpack/lazy-controller-loader.js
@@ -5583,7 +5583,7 @@ function getCommentsFromSource(source) {
     parse(source, {
         onComment: comments,
         sourceType: 'module',
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
     });
     return comments;
 }

--- a/src/util/get-stimulus-comment-options.ts
+++ b/src/util/get-stimulus-comment-options.ts
@@ -24,7 +24,7 @@ function getCommentsFromSource(source: string) {
     parse(source, {
         onComment: comments,
         sourceType: 'module',
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
     });
 
     return comments;

--- a/test/util/get-stimulus-comment-options.test.ts
+++ b/test/util/get-stimulus-comment-options.test.ts
@@ -42,4 +42,12 @@ describe('getStimulusCommentOptions', () => {
             errors: [],
         });
     });
+
+    it('parses source with static properties', () => {
+        const src = '/* stimulusFetch: "lazy" */ export default class extends Controller { static targets = []; }';
+        expect(getStimulusCommentOptions(src)).toEqual({
+            options: { stimulusFetch: 'lazy' },
+            errors: [],
+        });
+    });
 });


### PR DESCRIPTION
Fixes #84 

`acorn` should be configured to use ECMAScript version 2022 instead of 2020, which does not support static class properties.

See https://github.com/symfony/stimulus-bridge/issues/84#issuecomment-2383772104 for explanation.