### PR TITLE
[BREAKING] Drop Node.js 14 and 16 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: Test
 
+env:
+    NODE_VERSION_LOWEST_SUPPORTED: 18
+
 on:
     pull_request:
     push:
@@ -15,7 +18,7 @@ jobs:
             - name: Install Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 14 # lowest supported version
+                  node-version: ${{ env.NODE_VERSION_LOWEST_SUPPORTED }} # lowest supported version
 
             - name: Install Yarn Dependencies
               run: yarn install
@@ -32,7 +35,7 @@ jobs:
             - name: Install Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 14 # lowest supported version
+                  node-version: ${{ env.NODE_VERSION_LOWEST_SUPPORTED }} # lowest supported version
 
             - run: yarn install && yarn build
 
@@ -52,7 +55,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-versions: [ '14', '16', '18', '20', '22', '23' ]
+                node-versions: [ '18', '20', '22', '23' ]
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "author": "Titouan Galopin <galopintitouan@gmail.com>",
     "engines": {
-        "node": "^14.15.0 || ^16.10.0 || ^18.12.0 || ^20.0.0 || >=22.0"
+        "node": "^18.12.0 || ^20.0.0 || >=22.0"
     },
     "scripts": {
         "build": "yarn rollup -c",


### PR DESCRIPTION
Following #94, let's continue to drop old unmaintained [Node.js versions](https://nodejs.org/en/about/previous-releases):
<img width="757" alt="image" src="https://github.com/user-attachments/assets/1730bb19-02ce-4651-89b8-7acf84dfb720" />
