### PR TITLE
Move `acorn` dependency to devDependency, as it is already bundled in dist files, close #112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Thus having no effects on the `dist/` files, TypeScript `module` is now set to `ESNext`, `moduleResolution` to `NodeNext`, and `target` to `ES2021` by @Kocal in https://github.com/symfony/stimulus-bridge/pull/99
 * Upgrade minimum supported `acorn` version to 8.2.0 by @Kocal in https://github.com/symfony/stimulus-bridge/pull/110
 * Add support for `loader-utils@^3.0.0` and `schema-utils@^4.0.0` by @Kocal in https://github.com/symfony/stimulus-bridge/pull/111
+* Move `acorn` dependency to devDependency, as it is already bundled in dist files, by @Kocal in https://github.com/symfony/stimulus-bridge/pull/114
 
 ### Internal
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "dependencies": {
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",
         "@types/webpack-env": "^1.16.4",
-        "acorn": "^8.2.0",
         "loader-utils": "^2.0.0 || ^3.0.0",
         "schema-utils": "^3.0.0 || ^4.0.0"
     },
@@ -35,6 +34,7 @@
         "@rollup/plugin-typescript": "^12.1.2",
         "@symfony/mock-module": "file:test/fixtures/module",
         "@symfony/stimulus-testing": "^2.0.0",
+        "acorn": "^8.2.0",
         "babel-jest": "^27.3.1",
         "jest": "^27.3.1",
         "rolldown": "^1.0.0-beta.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@types/webpack-env':
         specifier: ^1.16.4
         version: 1.18.6
-      acorn:
-        specifier: ^8.2.0
-        version: 8.14.0
       loader-utils:
         specifier: ^2.0.0 || ^3.0.0
         version: 2.0.4
@@ -51,6 +48,9 @@ importers:
       '@symfony/stimulus-testing':
         specifier: ^2.0.0
         version: 2.0.1(@babel/core@7.26.7)
+      acorn:
+        specifier: ^8.2.0
+        version: 8.14.0
       babel-jest:
         specifier: ^27.3.1
         version: 27.5.1(@babel/core@7.26.7)
@@ -5805,11 +5805,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-jasmine2@27.5.1:
     dependencies:


### PR DESCRIPTION
```
Package size report
===================

Package info for "@symfony/stimulus-bridge@3.2.3": 3.1 MB
  Released: 2025-01-09 07:16:42.242 +0000 UTC (2w5d ago)
  Downloads last week: 12,772 (21.82%)
  Estimated traffic last week: 40 GB
  Subdependencies: 17

Removed dependencies:
  - acorn@8.14.0: 547 kB (17.38%)
    Downloads last week: 22,267,720 (N/A% from 8.14.0)
    Downloads last week from "@symfony/stimulus-bridge@3.2.3": 12,772 (N/A%)
    Traffic last week: N/A
    Traffic from "@symfony/stimulus-bridge@3.2.3": 40 GB (N/A%)
    Subdependencies: 0 (0%)

Estimated new statistics:
  Package size: 3.1 MB → 2.4 MB (74.94%)
  Subdependencies: 17 → 16 (-1)
  Traffic with last week's downloads:
    For current version: 40 GB → 30 GB (10 GB saved)
    For all versions: 184 GB → 138 GB (46 GB saved)
```

A little disappointed, I thought it would save more bandwidth, but it's still worth it!